### PR TITLE
Livereload set up globally

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,24 +5,18 @@ module.exports = function(grunt) {
     // Watches for changes and runs tasks
     // Livereload is setup for the 35729 port by default
     watch : {
+      options : {
+        livereload : true
+      },
       sass : {
         files : ['scss/**/*.scss'],
-        tasks : ['sass:dev', 'autoprefixer'],
-        options : {
-          livereload : 35729
-        }
+        tasks : ['sass:dev', 'autoprefixer']
       },
       js : {
-        files : ['js/**/*.js'],
-        options : {
-          livereload : 35729
-        }
+        files : ['js/**/*.js']
       },
       php : {
-        files : ['**/*.php'],
-        options : {
-          livereload : 35729
-        }
+        files : ['**/*.php']
       }
     },
 


### PR DESCRIPTION
Livereload can be set up globally, not at target level. Also you can either specify an `int port-number`, or true (This will use the default 35729 port).
This way you avoid to define 3 (or more times) `livereload : true`
Doc: https://github.com/gruntjs/grunt-contrib-watch#live-reloading
